### PR TITLE
Docs: mention the usage of `on.<>.paths`

### DIFF
--- a/preview/README.md
+++ b/preview/README.md
@@ -23,7 +23,7 @@ on:
   pull_request_target:
     types:
       - opened
-    # Execute this action only on PRs that touches
+    # Execute this action only on PRs that touch
     # documentation files.
     # paths:
     #   - "docs/**"

--- a/preview/README.md
+++ b/preview/README.md
@@ -23,6 +23,10 @@ on:
   pull_request_target:
     types:
       - opened
+    # Execute this action only on PRs that touches
+    # documentation files.
+    # paths:
+    #   - "docs/**"
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Add this as a comment so people can see it and adapt to their needs.

<!-- readthedocs-preview readthedocs-preview start -->
----
:books: Documentation preview :books:: https://readthedocs-preview--15.org.readthedocs.build/en/15/

<!-- readthedocs-preview readthedocs-preview end -->