### PR TITLE
Suggest documentation-links.yml

### DIFF
--- a/preview/README.md
+++ b/preview/README.md
@@ -16,7 +16,7 @@ https://docs.readthedocs.io/en/latest/pull-requests.html
 After that, create a [GitHub Action](https://docs.github.com/en/actions) in your repository with the following content:
 
 ```yaml
-# .github/workflows/pull-request-links.yaml
+# .github/workflows/documentation-links.yml
 
 name: readthedocs/actions
 on:
@@ -32,7 +32,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  pull-request-links:
+  documentation-links:
     runs-on: ubuntu-latest
     steps:
       - uses: readthedocs/actions/preview@v1


### PR DESCRIPTION
Feel free to close this idea!

Searching GitHub, looks like `documentation-links` is a popular choice for the file and job, so for consistency we could use the same name in the suggestion.

https://github.com/search?q=readthedocs%2Factions%2Fpreview+language%3AYAML&ref=opensearch&type=code&l=YAML&p=1

* 12 for `documentation-links`: https://github.com/search?q=readthedocs%2Factions%2Fpreview+path%3A**%2Fdocumentation-links.*++language%3AYAML&type=code
* 1 for `pull-request-links`: https://github.com/search?q=readthedocs%2Factions%2Fpreview+path%3A**%2Fpull-request-links.*++language%3AYAML&type=code

Plus workflow files are more commonly named `.yml`:

* 199k for `.yaml`: https://github.com/search?q=path%3A.github%2Fworkflows%2F*.yaml&type=code
* 1.7M for `.yml`: https://github.com/search?q=path%3A.github%2Fworkflows%2F*.yml&type=code


<!-- readthedocs-preview readthedocs-preview start -->
----
:books: Documentation preview :books:: https://readthedocs-preview--21.org.readthedocs.build/en/21/

<!-- readthedocs-preview readthedocs-preview end -->