### PR TITLE
action.yaml: fix message-template

### DIFF
--- a/preview/action.yaml
+++ b/preview/action.yaml
@@ -17,7 +17,7 @@ inputs:
   message-template:
     description: "Template message to use for the PR body"
     default: |
-      ----
+      ---
       :books: Documentation preview :books:: {docs-pr-index-url}
     required: false
   platform:


### PR DESCRIPTION
The message template contains four dashes,
and that apparently makes Github not render
the following books emoji. Use three dashes
instead.

The non-displaying emojis can be seen in #12,
or #16 for something more recent.

<!-- readthedocs-preview readthedocs-preview start -->



------

:books: Documentation preview :books: : https://readthedocs-preview--32.org.readthedocs.build/en/32/

<!-- readthedocs-preview readthedocs-preview end -->
