### PR TITLE
Bump actions/checkout and actions/github-script to their latest major versions

### DIFF
--- a/preview/action.yaml
+++ b/preview/action.yaml
@@ -32,13 +32,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: "readthedocs/actions"
         ref: "v1"
 
     - name: "Comment on Pull Request with Read the Docs' preview links"
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const inputs = {


### PR DESCRIPTION
This addresses deprecation warnings related to the version of Node used in the older actions.


<!-- readthedocs-preview readthedocs-preview start -->
----
📚 Documentation preview 📚: https://readthedocs-preview--40.org.readthedocs.build/en/40/

<!-- readthedocs-preview readthedocs-preview end -->