### PR TITLE
Specify write pull-requests permissions at job level rather than workflow level

### DIFF
--- a/preview/README.md
+++ b/preview/README.md
@@ -28,12 +28,11 @@ on:
     # paths:
     #   - "docs/**"
 
-permissions:
-  pull-requests: write
-
 jobs:
   documentation-links:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: readthedocs/actions/preview@v1
         with:


### PR DESCRIPTION
Given that there's a single job, it doesn't matter either way. However, we might as well scope the permissions more closely to where they are actually required. That way, if a user were to add additional jobs, they wouldn't default to having write permissions.