### PR TITLE
Use commit SHA for composed actions

### DIFF
--- a/preview/action.yaml
+++ b/preview/action.yaml
@@ -36,13 +36,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # https://github.com/actions/checkout/releases/tag/v3.6.0
       with:
         repository: "readthedocs/actions"
         ref: "v1"
 
     - name: "Comment on Pull Request with Read the Docs' preview links"
-      uses: actions/github-script@v6
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # https://github.com/actions/github-script/releases/tag/v6.4.1
       with:
         script: |
           const inputs = {


### PR DESCRIPTION
GitHub [recommends to use full-length commit SHAs in workflow files](https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information) to mitigate some supply chain attack vectors, like overwriting / force-pushing version tags with malicious commits.

To increase the security posture on a repository level, GitHub has added an [option](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository) to enforce that only full-length commit SHAs are allowed to be used in a repository. Activating this option effectively blocks actions from executing, if their reference does not use a full-length commit SHA.

Apparently nested includes from composite actions are affected as well. Meaning that any repository using readthedocs/actions/preview can not enable the above mentioned repository-wide restriction, without effectively breaking/disabling the preview action. The option can only be turned on or off completely. It is not possible to make exceptions for transitive action references (through composite actions).

The proposed changes should fix this problem by using full-length commit SHAs inside your composite action.

<!-- readthedocs-preview readthedocs-preview start -->
----
📚 Documentation preview 📚: https://readthedocs-preview--53.org.readthedocs.build/en/53/

<!-- readthedocs-preview readthedocs-preview end -->